### PR TITLE
Fixes #18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ salesforce.schema
 .idea/
 .sfdx/
 IlluminatedCloud/*
+.vscode/settings.json

--- a/config/project-scratch-def.json
+++ b/config/project-scratch-def.json
@@ -1,5 +1,6 @@
 {
   "orgName": "apex-fp",
   "edition": "Developer",
-  "features": []
+  "features": [],
+  "language": "en_US"
 }

--- a/sfdx-source/apex-fp/main/classes/util/PrimitiveComparer.cls
+++ b/sfdx-source/apex-fp/main/classes/util/PrimitiveComparer.cls
@@ -1,4 +1,15 @@
 public class PrimitiveComparer {
+
+	public Integer compareWithNull(Object a, Object b) {
+		if (a == null && b != null) {
+			return 1;
+		}
+		else if (a != null && b == null) {
+			return -1;
+		}
+		return 0;
+	}
+
 	public Integer compareBooleans(Boolean a, Boolean b) {
 		return (a == b) ? 0 : (a ? 1 : -1);
 	}
@@ -43,7 +54,10 @@ public class PrimitiveComparer {
 	 * A comparison for primitive data types
 	 */
 	public Integer compare(Object first, Object second) {
-		if (first instanceof Boolean && second instanceof Boolean) {
+		if (first == null || second == null) {
+			return compareWithNull(first, second);
+		}
+		else if (first instanceof Boolean && second instanceof Boolean) {
 			return this.compareBooleans((Boolean)first, (Boolean)second);
 		}
 		else if (first instanceof Date && second instanceof Date) {

--- a/sfdx-source/apex-fp/test/classes/util/PrimitiveComparerTest.cls
+++ b/sfdx-source/apex-fp/test/classes/util/PrimitiveComparerTest.cls
@@ -2,7 +2,7 @@
 private class PrimitiveComparerTest {
 
 	@IsTest
-	private static void nullValueCompariso() {
+	private static void nullValueComparison() {
 		PrimitiveComparer comparer = new PrimitiveComparer();
 		System.assertEquals(0, comparer.compare(null, null));
 		System.assertEquals(1, comparer.compare(null, 1));

--- a/sfdx-source/apex-fp/test/classes/util/PrimitiveComparerTest.cls
+++ b/sfdx-source/apex-fp/test/classes/util/PrimitiveComparerTest.cls
@@ -2,6 +2,14 @@
 private class PrimitiveComparerTest {
 
 	@IsTest
+	private static void nullValueCompariso() {
+		PrimitiveComparer comparer = new PrimitiveComparer();
+		System.assertEquals(0, comparer.compare(null, null));
+		System.assertEquals(1, comparer.compare(null, 1));
+		System.assertEquals(-1, comparer.compare(1, null));
+	}
+
+	@IsTest
 	private static void booleanComparison() {
 		PrimitiveComparer comparer = new PrimitiveComparer();
 		System.assertEquals(0, comparer.compareBooleans(true, true));


### PR DESCRIPTION
This PR aims to fix what is described on issue #18. Checks both parameters for null values and, if one of them is null, then return an integer based on that. Return zero if both values to be compared are null, one if only the first parameter is null and minus one if only the second parameter is null.

This also adds an extra file to be ignored by git and sets the org's default language to American English.